### PR TITLE
Non-printable characters fix and removed trailing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Heavily inspired by [kube-ps1](https://github.com/jonmosco/kube-ps1) by [jonmosc
 
 ## Contributors
 - [Frode Sundby](https://github.com/frodesundby)
+- [Vegar Sechmann Molvig](https://github.com/VegarM)
 
 ## Known issues
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ With no arguments, turn on/off kubeaware for this shell instance instance (defau
 ### Bash
 ```
 source kubeaware.sh
-export PS1="[your prompt] \$(kubeaware_prompt)$" # The output from the function `kubeaware_prompt` will have a whitespace at the end.
+export PS1="[your prompt] \$(kubeaware_prompt) $"
 ```
 
 ![installation_demo](img/installation.gif)
@@ -30,7 +30,7 @@ export PS1="[your prompt] \$(kubeaware_prompt)$" # The output from the function 
 ### Zsh
 ```
 source kubeaware.sh
-PROMPT='$(kubeaware_prompt)'$PROMPT
+PROMPT='$(kubeaware_prompt) '$PROMPT
 ```
 
 

--- a/kubeaware.sh
+++ b/kubeaware.sh
@@ -2,28 +2,26 @@
 
 [[ -n $DEBUG ]] && set -x
 
-_main () {
-        _init_env
-        _get_current_context
-        _get_current_namespace
-        if [ "${ZSH_VERSION}" ]
-        then
-                PRE_SYMBOL="%{$fg[blue]%}" 
-                POST_SYMBOL="%{$fg[white]%}" 
-                setopt PROMPT_SUBST
-                autoload -U add-zsh-hook
-                add-zsh-hook precmd _sync_kubeaware
-        elif [ "${BASH_VERSION}" ]
-        then
-                PRE_SYMBOL='\e[0;34m' 
-                POST_SYMBOL='\e[0;0m' 
-                PROMPT_COMMAND="_sync_kubeaware;${PROMPT_COMMAND}" 
-        fi
+function _main {
+  _init_env
+  _get_current_context
+  _get_current_namespace
+  if [ "${ZSH_VERSION}" ]; then
+    PRE_SYMBOL="%{$fg[blue]%}" 
+    POST_SYMBOL="%{$fg[white]%}" 
+    setopt PROMPT_SUBST
+    autoload -U add-zsh-hook
+    add-zsh-hook precmd _sync_kubeaware
+  elif [ "${BASH_VERSION}" ]; then
+    PRE_SYMBOL='\e[0;34m' 
+    POST_SYMBOL='\e[0;0m' 
+    PROMPT_COMMAND="_sync_kubeaware;${PROMPT_COMMAND}" 
+  fi
 }
 
 function _init_env {
   KUBECTL=kubectl
-  KUBE_SYMBOL=$'\u2388' 
+  KUBE_SYMBOL=$'\u2388'
   DEFAULT_NAMESPACE_ALIAS="~"
   KUBEDIR="${HOME}/.kube"
   KUBECONFIG_FILE=${KUBECONFIG:-"${KUBEDIR}/config"}
@@ -33,12 +31,11 @@ function _init_env {
   mkdir -p "${KUBEDIR}"
 }
 
-kubeaware_prompt () {
+function kubeaware_prompt {
   if [[ ( -f "${KUBEAWARE_GLOBAL_ENABLED_FILE}" || -n ${KUBEAWARE} ) && -z "${KUBEUNAWARE}" ]]; then
-    echo "[${PRE_SYMBOL}${KUBE_SYMBOL}${POST_SYMBOL} ${CURRENT_CTX}:${CURRENT_NS}]"
+    echo -e "[${PRE_SYMBOL}${KUBE_SYMBOL}${POST_SYMBOL} ${CURRENT_CTX}:${CURRENT_NS}]"
   fi
 }
-
 
 function kubeaware {
   if [[ "${1}" == "-h" || "${1}" == "--help" ]]; then

--- a/kubeaware.sh
+++ b/kubeaware.sh
@@ -2,22 +2,28 @@
 
 [[ -n $DEBUG ]] && set -x
 
-function _main {
-  _init_env
-  _get_current_context
-  _get_current_namespace
-  if [ "${ZSH_VERSION}" ]; then
-    setopt PROMPT_SUBST
-    autoload -U add-zsh-hook
-    add-zsh-hook precmd _sync_kubeaware
-  elif [ "${BASH_VERSION}" ]; then
-    PROMPT_COMMAND="_sync_kubeaware;${PROMPT_COMMAND}"
-  fi
+_main () {
+        _init_env
+        _get_current_context
+        _get_current_namespace
+        if [ "${ZSH_VERSION}" ]
+        then
+                PRE_SYMBOL="%{$fg[blue]%}" 
+                POST_SYMBOL="%{$fg[white]%}" 
+                setopt PROMPT_SUBST
+                autoload -U add-zsh-hook
+                add-zsh-hook precmd _sync_kubeaware
+        elif [ "${BASH_VERSION}" ]
+        then
+                PRE_SYMBOL='\e[0;34m' 
+                POST_SYMBOL='\e[0;0m' 
+                PROMPT_COMMAND="_sync_kubeaware;${PROMPT_COMMAND}" 
+        fi
 }
 
 function _init_env {
   KUBECTL=kubectl
-  KUBE_SYMBOL=$'\e[0;34m\u2388 \e[0m'
+  KUBE_SYMBOL=$'\u2388' 
   DEFAULT_NAMESPACE_ALIAS="~"
   KUBEDIR="${HOME}/.kube"
   KUBECONFIG_FILE=${KUBECONFIG:-"${KUBEDIR}/config"}
@@ -27,11 +33,12 @@ function _init_env {
   mkdir -p "${KUBEDIR}"
 }
 
-function kubeaware_prompt {
-  if [[ ( -f "${KUBEAWARE_GLOBAL_ENABLED_FILE}" || -n ${KUBEAWARE}) && -z "${KUBEUNAWARE}" ]]; then
-    echo -e "[${KUBE_SYMBOL}${CURRENT_CTX}:${CURRENT_NS}] "
+kubeaware_prompt () {
+  if [[ ( -f "${KUBEAWARE_GLOBAL_ENABLED_FILE}" || -n ${KUBEAWARE} ) && -z "${KUBEUNAWARE}" ]]; then
+    echo "[${PRE_SYMBOL}${KUBE_SYMBOL}${POST_SYMBOL} ${CURRENT_CTX}:${CURRENT_NS}]"
   fi
 }
+
 
 function kubeaware {
   if [[ "${1}" == "-h" || "${1}" == "--help" ]]; then

--- a/kubeaware.sh
+++ b/kubeaware.sh
@@ -13,8 +13,8 @@ function _main {
     autoload -U add-zsh-hook
     add-zsh-hook precmd _sync_kubeaware
   elif [ "${BASH_VERSION}" ]; then
-    PRE_SYMBOL='\e[0;34m' 
-    POST_SYMBOL='\e[0;0m' 
+    PRE_SYMBOL='\001\033[34m\002'
+    POST_SYMBOL='\001\033[39m\002' 
     PROMPT_COMMAND="_sync_kubeaware;${PROMPT_COMMAND}" 
   fi
 }


### PR DESCRIPTION
Changed to ZSH-way of colors in prompt, with proper ZSH escape sequence for non-printable characters.

Also removed trailing whitespace in `kubeaware_prompt` because it should be optional if you want this whitespace in your prompt.